### PR TITLE
xapian-glib: Use xapian-config-1.3

### DIFF
--- a/com.endlessm.Sdk.json.in
+++ b/com.endlessm.Sdk.json.in
@@ -132,6 +132,9 @@
         },
         {
             "name": "xapian-glib",
+            "config-opts": [
+                "--with-xapian-config=xapian-config-1.3"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
xapian-glib will now by default look for xapian-core.pc, but we use
xapian-1.3 which doesn't have that. We need to specify xapian-config-1.3
manually now.

https://phabricator.endlessm.com/T15613