### PR TITLE
manifest: Add Basin

### DIFF
--- a/com.endlessm.Sdk.json.in
+++ b/com.endlessm.Sdk.json.in
@@ -219,6 +219,21 @@
             ]
         },
         {
+            "name": "basin",
+            "cleanup-platform": [
+                "/bin/basin",
+                "/bin/basin-helper",
+                "/bin/basin-processor",
+                "/share/basin"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/basin.git"
+                }
+            ]
+        },
+        {
             "name": "mathjax-js",
             "no-autogen": true,
             "sources": [


### PR DESCRIPTION
Basin is a developer tool that we should have in the SDK. It does not
need to go in the platform.

https://phabricator.endlessm.com/T17171