### PR TITLE
manifest: Add eos-metrics

### DIFF
--- a/com.endlessm.Sdk.json.in
+++ b/com.endlessm.Sdk.json.in
@@ -63,6 +63,50 @@
             ]
         },
         {
+            "name": "python-dbus",
+            "no-autogen": true,
+            "cleanup": ["*"],
+            "build-options": {
+                "env": {
+                    "PYTHON": "/usr/bin/python3"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/ad/1b/76adc363212c642cabbf9329457a918308c0b9b5d38ce04d541a67255174/dbus-python-1.2.4.tar.gz",
+                    "sha256": "e2f1d6871f74fba23652e51d10873e54f71adab0525833c19bad9e99b1b2f9cc"
+                },
+                {
+                    "type": "file",
+                    "path": "setuptools-makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
+            "name": "python-dbusmock",
+            "no-autogen": true,
+            "cleanup": ["*"],
+            "build-options": {
+                "env": {
+                    "PYTHON": "/usr/bin/python3"
+                }
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/61/08/31ccd635c7a73575ce3682471811de6f046793319374e455bf990451733c/python-dbusmock-0.16.7.tar.gz",
+                    "sha256": "2d2ea892fa4633c3ec6ac1e912120ec493047a5c6522849b7d1c95ad755bce75"
+                },
+                {
+                    "type": "file",
+                    "path": "setuptools-makefile",
+                    "dest-filename": "Makefile"
+                }
+            ]
+        },
+        {
             "name": "libyaml",
             "sources": [
                 {
@@ -113,6 +157,19 @@
             "post-install": [
                 "chmod 0755 /usr/lib/libtcl8.6.so",
                 "ln -s /usr/bin/tclsh8.6 /usr/bin/tclsh"
+            ]
+        },
+        {
+            "name": "eos-metrics",
+            "config-opts": [
+                "--disable-gtk-doc",
+                "--disable-gir-doc"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/eos-metrics"
+                }
             ]
         },
         {
@@ -170,7 +227,6 @@
                     "--disable-gtk-doc",
                     "--disable-gir-doc",
                     "--disable-js-doc",
-                    "--disable-metrics",
                     "--disable-webhelper"
                 ]
             },
@@ -437,7 +493,6 @@
             "name": "eos-knowledge-lib",
             "cleanup-platform": ["*.scss"],
             "config-opts": [
-                "--disable-metrics",
                 "--disable-js-doc",
                 "--with-mathjax-dir=/usr/share/javascript/mathjax"
             ],


### PR DESCRIPTION
Also requires two Python modules: dbus and dbusmock. Remove all
--disable-metrics configure options from modules with an eos-metrics
dependency.

https://phabricator.endlessm.com/T17181