### PR TITLE
manifest: Remove xapian-bridge

### DIFF
--- a/com.endlessm.Sdk.json.in
+++ b/com.endlessm.Sdk.json.in
@@ -200,15 +200,6 @@
             ]
         },
         {
-            "name": "xapian-bridge",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/endlessm/xapian-bridge"
-                }
-            ]
-        },
-        {
             "name": "jasmine-gjs",
             "sources": [
                 {


### PR DESCRIPTION
xapian-bridge is a service provided by the OS, so we don't need to build
it as part of the SDK.

https://phabricator.endlessm.com/T17311