### PR TITLE
xapian: Don't error out on ARM for -Wcast-align

### DIFF
--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -178,10 +178,17 @@
             "name": "xapian-1.3",
             "subdir": "xapian-core",
             "builddir": false,
-            "config-opts": [
-                "--enable-maintainer-mode",
-                "--disable-documentation"
-            ],
+            "build-options": {
+                "config-opts": [
+                    "--enable-maintainer-mode",
+                    "--disable-documentation"
+                ],
+                "arch": {
+                    "arm": {
+                        "cxxflags": "-Wno-error=cast-align"
+                    }
+                }
+            },
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
This should probably be fixed in upstream Xapian, but we were already
ignoring it in our builds without any apparent consequences.

https://phabricator.endlessm.com/T17867