### PR TITLE
build: Install Docs extension as preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ GNOME_DEPS = \
 	org.gnome.Sdk/${ARCH}/${GNOME_RUNTIME_VERSION} \
 	org.gnome.Sdk.Locale/${ARCH}/${GNOME_RUNTIME_VERSION} \
 	org.gnome.Sdk.Debug/${ARCH}/${GNOME_RUNTIME_VERSION} \
+	org.gnome.Sdk.Docs/${ARCH}/${GNOME_RUNTIME_VERSION} \
 	$()
 
 SUBST_FILES = \


### PR DESCRIPTION
It's now required for the build.

https://phabricator.endlessm.com/T19103