### PR TITLE
build: Don't use no-make-install

### DIFF
--- a/clean-out-old-gstreamer-makefile
+++ b/clean-out-old-gstreamer-makefile
@@ -3,3 +3,6 @@ all:
 	for plugin in $(wildcard /usr/lib/gstreamer-1.0/*.so); do \
 		install -D dummy $$plugin; \
 	done
+
+install:
+	true

--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -47,7 +47,6 @@
         {
             "name": "clean-out-old-gstreamer",
             "no-autogen": true,
-            "no-make-install": true,
             "ensure-writable": ["/usr/lib/gstreamer-1.0/*"],
             "sources": [
                 {


### PR DESCRIPTION
In the dummy gstreamer cleaner makefile we have to provide an install
target, as no-make-install doesn't exist in flatpak-builder 0.8.

https://phabricator.endlessm.com/T19103