### PR TITLE
Build custom libvpx

### DIFF
--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -389,6 +389,32 @@
             ]
         },
         {
+            "name": "libvpx",
+            "build-options": {
+                "config-opts": [
+                    "--target=x86_64-linux-gcc",
+                    "--enable-pic",
+                    "--enable-vp8",
+                    "--enable-vp9",
+                    "--enable-libs",
+                    "--disable-install-docs",
+                    "--disable-static",
+                    "--enable-shared"
+                ]
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.6.1.tar.bz2",
+                    "sha256": "1c2c0c2a97fba9474943be34ee39337dee756780fc12870ba1dc68372586a819"
+                },
+                {
+                    "type": "patch",
+                    "path": "vpx.patch"
+                }
+            ]
+        },
+        {
             "name": "gstreamer-plugins-good",
             "build-options" : {
                 "arch" : {

--- a/vpx.patch
+++ b/vpx.patch
@@ -1,0 +1,16 @@
+Required for working around read-only filesystem bug.
+
+https://github.com/flatpak/flatpak/issues/1024
+
+--- a/build/make/Makefile	2017-09-20 16:05:50.194442138 -0700
++++ b/build/make/Makefile	2017-09-20 16:06:14.445782003 -0700
+@@ -273,8 +273,7 @@
+ define install_map_template
+ $(DIST_DIR)/$(1): $(2)
+ 	$(if $(quiet),@echo "    [INSTALL] $$@")
+-	$(qexec)mkdir -p $$(dir $$@)
+-	$(qexec)cp -p $$< $$@
++	$(qexec)install -Dp $$< $$@
+ endef
+ 
+ define archive_template


### PR DESCRIPTION
The libvpx in the freedesktop base SDK doesn't take advantage of assembly
on x86_64, making its performance a lot worse. Instead, build our own
copy (which subsequently gets picked up by gstreamer-plugins-good) and
make sure its target is set to x86_64 instead of generic.

NOTE: This commit should NOT be cherry picked to the sdk-arm-1 branch. The freedesktop base SDK does already build an arch-specific libvpx for ARM.

https://phabricator.endlessm.com/T19187