### PR TITLE
xapian-core: Don't use subdir

### DIFF
--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -180,7 +180,6 @@
         },
         {
             "name": "xapian-1.3",
-            "subdir": "xapian-core",
             "builddir": false,
             "build-options": {
                 "config-opts": [


### PR DESCRIPTION
We've fixed the xapian-core tree so that the toplevel autogen.sh works
for our purposes.

https://phabricator.endlessm.com/T19404