### PR TITLE
enable app icon overrides in EndlessOS icon theme

### DIFF
--- a/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
+++ b/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
@@ -16,6 +16,7 @@
         {
             "name": "eos-theme",
             "config-opts": [
+                "--enable-app-icons",
                 "--disable-fonts",
                 "--disable-settings"
             ],


### PR DESCRIPTION
We wish to ship the Endless OS app icon overrides in the Flatpak extension only, but not in the OS. https://github.com/endlessm/eos-theme/pull/288 disables them by default in eos-theme, so we enable them explicitly here.

https://phabricator.endlessm.com/T20599