### PR TITLE
Revert "tcl: Include in SDK"

### DIFF
--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -132,7 +132,7 @@
         {
             "name": "tcl",
             "no-autogen": true,
-            "cleanup-platform": ["*"],
+            "cleanup": ["*"],
             "builddir": false,
             "subdir": "unix",
             "config-opts": [


### PR DESCRIPTION
This reverts commit 521f2e2e8d6cf333efc7112c3fdbd43d6b30c03c.

This is more trouble than it's worth, so we decided to just not build
xapian-core in CI. It's being built and tested internally on OBS anyway.

https://phabricator.endlessm.com/T21026