### PR TITLE
tcl: Make /usr/bin/tclsh writable

### DIFF
--- a/com.endlessm.apps.Sdk.json.in
+++ b/com.endlessm.apps.Sdk.json.in
@@ -152,6 +152,9 @@
             "post-install": [
                 "chmod 0755 /usr/lib/libtcl8.6.so",
                 "ln -s /usr/bin/tclsh8.6 /usr/bin/tclsh"
+            ],
+            "ensure-writable": [
+                "/usr/bin/tclsh"
             ]
         },
         {


### PR DESCRIPTION
For some reason, this file existed even though there was no tcl in the
GNOME or fd.o manifests. The best we can figure is to overwrite it.

https://phabricator.endlessm.com/T21026