### PR TITLE
sdk: Add mustache-c, bison and flex

### DIFF
--- a/com.endlessm.apps.Sdk.json.in.in
+++ b/com.endlessm.apps.Sdk.json.in.in
@@ -502,6 +502,16 @@
             ]
         },
         {
+            "name": "mustache-c",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/x86-64/mustache-c.git",
+                    "commit": "01f1e4732c4862071bbf07242128abf1e28cc105"
+                }
+            ]
+        },
+        {
             "name": "eos-knowledge-lib",
             "cleanup-platform": [
                 "*.scss",


### PR DESCRIPTION
We're going to use mustache-c in T21272 in order to port
articleHTMLRenderer to C. Bison and Flex are required to
build mustache-c.

https://phabricator.endlessm.com/T21272