### PR TITLE
manifest: Select correct branch of org.gnome.Sdk.Docs

### DIFF
--- a/com.endlessm.apps.Sdk.json.in.in
+++ b/com.endlessm.apps.Sdk.json.in.in
@@ -22,6 +22,7 @@
     ],
     "add-extensions": {
         "org.gnome.Sdk.Docs" : {
+            "version": "@@GNOME_RUNTIME_VERSION@@",
             "directory": "share/runtime/docs",
             "bundle": true,
             "autodelete": true,


### PR DESCRIPTION
Without this, you'll have to have org.gnome.Sdk.Docs//master installed
from gnome-nightly.

https://phabricator.endlessm.com/T21545