### PR TITLE
Update the version of Xapian

### DIFF
--- a/com.endlessm.apps.Sdk.json.in.in
+++ b/com.endlessm.apps.Sdk.json.in.in
@@ -208,7 +208,12 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/endlessm/xapian-core"
+                    "url": "https://git.xapian.org/xapian",
+                    "commit": "81dd4862b907fa40380996532b54b6633bd355dd"
+                },
+                {
+                    "type": "shell",
+                    "commands": [ "./bootstrap --download-tools=never xapian-core" ]
                 }
             ]
         },


### PR DESCRIPTION
We're going to be using Xapian 1.5/1.6 from now on; the xapian-next
branch is the branch we use for tracking the development of Xapian.

https://phabricator.endlessm.com/T21284