### PR TITLE
manifest: Include libdmodel

### DIFF
--- a/com.endlessm.apps.Sdk.json.in.in
+++ b/com.endlessm.apps.Sdk.json.in.in
@@ -295,6 +295,16 @@
             ]
         },
         {
+            "name": "libdmodel",
+            "buildsystem": "meson",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/endlessm/libdmodel.git"
+                }
+            ]
+        },
+        {
             "name": "basin",
             "cleanup-platform": [
                 "/bin/basin",


### PR DESCRIPTION
This is a library that was previously private and embedded in
eos-knowledge-lib. It's used for the data models for offline content,
and queries to the Xapian databases.

https://phabricator.endlessm.com/T21655