### PR TITLE
Add extension point for GTK+ modules

### DIFF
--- a/com.endlessm.apps.Sdk.json.tmpl
+++ b/com.endlessm.apps.Sdk.json.tmpl
@@ -27,11 +27,19 @@
             "bundle": true,
             "autodelete": true,
             "no-autodownload": true
+        },
+        "org.gtk.Gtk3module" : {
+            "directory": "lib/gtk3-modules",
+            "merge-dirs": "modules",
+            "no-autodownload": true,
+            "subdirectories": true,
+            "version": "3.0"
         }
     },
     "finish-args": [
         "--env=GI_TYPELIB_PATH=/app/lib/girepository-1.0",
         "--env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/extensions/gstreamer-1.0:/usr/lib/gstreamer-1.0",
+        "--env=GTK_PATH=/usr/lib/gtk3-modules",
         "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/share",
         "--sdk=com.endlessm.apps.Sdk//@@SDK_BRANCH@@",
         "--runtime=com.endlessm.apps.Platform//@@SDK_BRANCH@@"


### PR DESCRIPTION
GTK+ modules provide extra functionality to GTK+, so this patch adds
the extension point to the freedesktop Platform and Sdk runtimes,
making it easy for those modules to be used with Flatpak apps.

Extensions that have GTK+ modules should have an org.gtk.Gtk3module as
a prefix in their name. The version for the extensions should the same
as GTK+'s (3.0).
Note that in order for the actual modules to be loaded, they have to
be added to the GTK3_MODULES environment variable (passed Flatpak when
running an app).

https://phabricator.endlessm.com/T23764