### PR TITLE
Add apitrace to the apps Sdk

### DIFF
--- a/com.endlessm.apps.Sdk.json.tmpl
+++ b/com.endlessm.apps.Sdk.json.tmpl
@@ -613,6 +613,17 @@
                     "dest-filename": "configure"
                 }
             ]
+        },
+        {
+            "name": "apitrace",
+            "buildsystem": "cmake",
+            "cleanup-platform": ["*"],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/apitrace/apitrace"
+                }
+            ]
         }
 
     ]


### PR DESCRIPTION
Think we could add this to the apps Sdk? It would be helpful to have apitrace more readily available for debugging opengl issues on different systems.