### PR TITLE
Disable faces installation in eos-theme

### DIFF
--- a/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
+++ b/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
@@ -18,7 +18,8 @@
             "config-opts": [
                 "--enable-app-icons",
                 "--disable-fonts",
-                "--disable-settings"
+                "--disable-settings",
+                "--disable-faces"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Building the EndlessOS icon theme currently fails because
/usr/share/runtime/share/pixmaps is read-only. Disable installing the
faces icons as they're only relevant to the host OS. This depends on the
--disable-faces option in eos-theme.

This requires endlessm/eos-theme#333 to be merged.

https://phabricator.endlessm.com/T28493