### PR TITLE
Arm64 for SDK 4

### DIFF
--- a/generate-manifest.py
+++ b/generate-manifest.py
@@ -16,6 +16,7 @@ from gi.repository import Flatpak
 DEBIAN_TO_FLATPAK_ARCH_OVERRIDES = {
     'armhf': 'arm',
     'amd64': 'x86_64',
+    'arm64': 'aarch64',
 }
 
 FLATPAK_TO_DEBIAN_ARCH_OVERRIDES = \
@@ -79,7 +80,9 @@ def edit_manifest(data, arch, branch, runtime_version):
             'gtk3-egl-x11.patch',
         ],
         'x86_64': [
-        ]
+        ],
+        'aarch64': [
+        ],
     }
 
     gtk_config_opts = {
@@ -90,6 +93,8 @@ def edit_manifest(data, arch, branch, runtime_version):
             '--build=arm-unknown-linux-gnueabi',
         ],
         'x86_64': [
+        ],
+        'aarch64': [
         ],
     }
 

--- a/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
+++ b/org.freedesktop.Platform.Icontheme.EndlessOS.json.in
@@ -18,7 +18,8 @@
             "config-opts": [
                 "--enable-app-icons",
                 "--disable-fonts",
-                "--disable-settings"
+                "--disable-settings",
+                "--disable-faces"
             ],
             "sources": [
                 {


### PR DESCRIPTION
Build an Arm64 port of the SDK v4. This also includes the change to not install the faces from eos-theme (the new builder has fuse-rofiles so flatpak-builder uses it and then the same error occours but from the logs I see that the older builder didn't so that feature wasn't used and the build succeeded).

https://phabricator.endlessm.com/T27755