### PR TITLE
Arm64 builds for SDK5

### DIFF
--- a/generate-manifest.py
+++ b/generate-manifest.py
@@ -16,6 +16,7 @@ from gi.repository import Flatpak
 DEBIAN_TO_FLATPAK_ARCH_OVERRIDES = {
     'armhf': 'arm',
     'amd64': 'x86_64',
+    'arm64': 'aarch64',
 }
 
 FLATPAK_TO_DEBIAN_ARCH_OVERRIDES = \
@@ -82,7 +83,9 @@ def edit_manifest(data, arch, branch, runtime_version):
             'gtk3-egl-x11.patch',
         ],
         'x86_64': [
-        ]
+        ],
+        'aarch64': [
+        ],
     }
 
     gtk_config_opts = {
@@ -93,6 +96,9 @@ def edit_manifest(data, arch, branch, runtime_version):
             '--build=arm-unknown-linux-gnueabi',
         ],
         'x86_64': [
+        ],
+        'aarch64': [
+            '--build=aarch64-unknown-linux-gnu',
         ],
     }
 
@@ -111,7 +117,9 @@ def edit_manifest(data, arch, branch, runtime_version):
         'arm': [
         ],
         'x86_64': [
-        ]
+        ],
+        'aarch64': [
+        ],
     }
 
     gst_plugins_base_patches = {
@@ -121,7 +129,9 @@ def edit_manifest(data, arch, branch, runtime_version):
         'arm': [
         ],
         'x86_64': [
-        ]
+        ],
+        'aarch64': [
+        ],
     }
 
     gst_plugins_base_config_opts = {
@@ -131,6 +141,8 @@ def edit_manifest(data, arch, branch, runtime_version):
             '--disable-glx',
         ],
         'x86_64': [
+        ],
+        'aarch64': [
         ],
     }
 


### PR DESCRIPTION
Enable Arm64 port for the SDK v5. You can see the output at https://ci.endlessm-sf.com/view/SDK/job/sdk-aarch64-5/3/ .

https://phabricator.endlessm.com/T27755