### PR TITLE
Add aarch64.

### DIFF
--- a/generate-manifest.py
+++ b/generate-manifest.py
@@ -129,7 +129,9 @@ def edit_manifest(data, arch, branch, runtime_version):
         'arm': [
         ],
         'x86_64': [
-        ]
+        ],
+        'aarch64': [
+        ],
     }
 
     gst_plugins_base_config_opts = {
@@ -139,6 +141,8 @@ def edit_manifest(data, arch, branch, runtime_version):
             '--disable-glx',
         ],
         'x86_64': [
+        ],
+        'aarch64': [
         ],
     }
 


### PR DESCRIPTION
This part differs from master and was missed in the backport.

Turns out you were right to have a separate branch. The cherry-pick missed these parts and the build failed.

https://phabricator.endlessm.com/T27755