### PR TITLE
Add libarchive dependency to libdmodel

### DIFF
--- a/elements/sdk/libdmodel.bst
+++ b/elements/sdk/libdmodel.bst
@@ -5,6 +5,7 @@ build-depends:
 - sdk-build-depends/jasmine-gjs.bst
 
 depends:
+- freedesktop-sdk.bst:components/libarchive.bst
 - gnome-sdk.bst:sdk/glib.bst
 - gnome-sdk.bst:sdk/json-glib.bst
 - gnome-sdk.bst:sdk/libsoup.bst


### PR DESCRIPTION
This is to get https://github.com/endlessm/libdmodel/pull/14 built.

https://phabricator.endlessm.com/T29258