### PR TITLE
Dylanmccall/custom webkitgtk for arm

### DIFF
--- a/elements/sdk-depends/maxwell.bst
+++ b/elements/sdk-depends/maxwell.bst
@@ -5,10 +5,10 @@ build-depends:
 
 depends:
 - gnome-sdk-sdk/gtk+-3.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - gnome-sdk.bst:sdk/glib.bst
 - gnome-sdk.bst:sdk/gobject-introspection.bst
 - gnome-sdk.bst:sdk/json-glib.bst
-- gnome-sdk.bst:sdk/WebKitGTK.bst
 
 sources:
 - kind: git_tag

--- a/elements/sdk-platform.bst
+++ b/elements/sdk-platform.bst
@@ -25,10 +25,11 @@ depends:
 # replaced (patched) elements:
 - gnome-sdk-sdk/gst-plugins-good.bst
 - gnome-sdk-sdk/gtk+-3.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - sdk/os-release.bst
 
 # upstream modules:
-- gnome-sdk.bst:sdk/WebKitGTK.bst
+# - gnome-sdk.bst:sdk/WebKitGTK.bst
 - gnome-sdk.bst:sdk/adwaita-icon-theme.bst
 - gnome-sdk.bst:sdk/appstream-glib.bst
 - gnome-sdk.bst:sdk/at-spi2-atk.bst

--- a/elements/sdk/eos-knowledge-lib.bst
+++ b/elements/sdk/eos-knowledge-lib.bst
@@ -10,7 +10,7 @@ build-depends:
 
 depends:
 - freedesktop-sdk.bst:components/gstreamer.bst
-- gnome-sdk.bst:sdk/WebKitGTK.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - gnome-sdk.bst:core/evince.bst
 - gnome-sdk.bst:sdk/gjs.bst
 - sdk-depends/emeus.bst


### PR DESCRIPTION
This is ready to go in case we need it based on https://phabricator.endlessm.com/T29524. Adds our own WebKitGTK.bst element, replacing the one in gnome-sdk.bst. There is only one difference from upstream: for the arm architecture, we build WebKitGTK with `-DENABLE_GLES2=ON` to enable OpenGL ES 2.0. Normally, the build system decides whether to do this automatically.

Ideally we can get by without this since it is expensive, but I suspect we might need it. We should check with upstream if they would be interested to build WebKitGTK this way _themselves_.