### PR TITLE
Include our custom WebKitGTK build on arm

### DIFF
--- a/elements/gnome-sdk-sdk/WebKitGTK-endless-arm.bst
+++ b/elements/gnome-sdk-sdk/WebKitGTK-endless-arm.bst
@@ -1,0 +1,94 @@
+# Replaces sdk/WebKitGTK.bst from gnome-sdk.
+# <https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-36/elements/sdk/WebKitGTK.bst>
+
+# Because the upstream version of this is required by other elements in
+# gnome-sdk, we need to keep the existing element intact, and put this one on
+# top of it during integration by using an overlap whitelist.
+
+kind: cmake
+
+sources:
+- kind: tar
+  url: webkitgtk_org:webkitgtk-2.27.91.tar.xz
+  ref: 30411781f620c33f5542a745930b48a19a6072bea0e68982c1ad863d1148bdea
+- kind: patch
+  path: gnome-sdk-files/webkitgtk/gtk-doc-introspection-cross-compiling.patch
+- kind: local
+  path: gnome-sdk-files/webkitgtk/toolchain.i686
+- kind: local
+  path: gnome-sdk-files/webkitgtk/toolchain.arm
+
+build-depends:
+- freedesktop-sdk.bst:components/gperf.bst
+- freedesktop-sdk.bst:components/perl.bst
+- freedesktop-sdk.bst:components/ruby.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/hyphen.bst
+- freedesktop-sdk.bst:components/libtasn1.bst
+- freedesktop-sdk.bst:components/libwebp.bst
+- freedesktop-sdk.bst:components/libxslt.bst
+- freedesktop-sdk.bst:components/wayland.bst
+- freedesktop-sdk.bst:components/xorg-lib-xt.bst
+- gnome-sdk-sdk/gtk+-3.bst
+- gnome-sdk.bst:sdk/at-spi2-core.bst
+- gnome-sdk.bst:sdk/brotli.bst
+- gnome-sdk.bst:sdk/enchant-2.bst
+- gnome-sdk.bst:sdk/geoclue.bst
+- gnome-sdk.bst:sdk/gobject-introspection.bst
+- gnome-sdk.bst:sdk/gst-plugins-base.bst
+- gnome-sdk.bst:sdk/libnotify.bst
+- gnome-sdk.bst:sdk/libsecret.bst
+- gnome-sdk.bst:sdk/libsoup.bst
+- gnome-sdk.bst:sdk/libwpe.bst
+- gnome-sdk.bst:sdk/openjpeg.bst
+- gnome-sdk.bst:sdk/pango.bst
+- gnome-sdk.bst:sdk/woff2.bst
+- gnome-sdk.bst:sdk/wpebackend-fdo.bst
+
+runtime-depends:
+- gnome-sdk-sdk/gst-plugins-good.bst
+- gnome-sdk.bst:sdk/gst-libav.bst
+- gnome-sdk.bst:sdk/gst-plugins-bad.bst
+
+# dummy dependency so this is staged on top of the element from gnome-sdk
+- gnome-sdk.bst:sdk/WebKitGTK.bst
+
+variables:
+  webkitgtk_toolchain: ''
+  endless_arch_options: ''
+  (?):
+  - arch == "i686" or arch == "arm":
+      webkitgtk_toolchain: -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain.%{arch}
+  - arch == "arm":
+      endless_arch_options: |
+        -DENABLE_GLES2=ON
+  cmake-local: >-
+    -DPORT=GTK
+    -DENABLE_BUBBLEWRAP_SANDBOX=OFF
+    %{webkitgtk_toolchain}
+    %{endless_arch_options}
+(?):
+- arch == "i686":
+    environment:
+      CFLAGS: '%{flags_i686} -g1'
+      CXXFLAGS: '%{flags_i686} -g1'
+- arch == "arm":
+    environment:
+      CFLAGS: '%{flags_arm} -g1'
+      CXXFLAGS: '%{flags_arm} -g1'
+
+public:
+  bst:
+    split-rules:
+      devel:
+        (>):
+        - '%{libdir}/libjavascriptcoregtk-4.0.so'
+        - '%{libdir}/libwebkit2gtk-4.0.so'
+    overlap-whitelist:
+    - '**'
+  cpe:
+    product: webkitgtk+
+

--- a/elements/gnome-sdk-sdk/WebKitGTK.bst
+++ b/elements/gnome-sdk-sdk/WebKitGTK.bst
@@ -1,93 +1,10 @@
-# Replaces sdk/WebKitGTK.bst from gnome-sdk.
-# <https://gitlab.gnome.org/GNOME/gnome-build-meta/blob/gnome-3-36/elements/sdk/WebKitGTK.bst>
+kind: stack
 
-# Because the upstream version of this is required by other elements in
-# gnome-sdk, we need to keep the existing element intact, and put this one on
-# top of it during integration by using an overlap whitelist.
-
-kind: cmake
-
-sources:
-- kind: tar
-  url: webkitgtk_org:webkitgtk-2.27.91.tar.xz
-  ref: 30411781f620c33f5542a745930b48a19a6072bea0e68982c1ad863d1148bdea
-- kind: patch
-  path: gnome-sdk-files/webkitgtk/gtk-doc-introspection-cross-compiling.patch
-- kind: local
-  path: gnome-sdk-files/webkitgtk/toolchain.i686
-- kind: local
-  path: gnome-sdk-files/webkitgtk/toolchain.arm
-
-build-depends:
-- freedesktop-sdk.bst:components/gperf.bst
-- freedesktop-sdk.bst:components/perl.bst
-- freedesktop-sdk.bst:components/ruby.bst
-- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
-
-depends:
-- freedesktop-sdk.bst:bootstrap-import.bst
-- freedesktop-sdk.bst:components/hyphen.bst
-- freedesktop-sdk.bst:components/libtasn1.bst
-- freedesktop-sdk.bst:components/libwebp.bst
-- freedesktop-sdk.bst:components/libxslt.bst
-- freedesktop-sdk.bst:components/wayland.bst
-- freedesktop-sdk.bst:components/xorg-lib-xt.bst
-- gnome-sdk-sdk/gtk+-3.bst
-- gnome-sdk.bst:sdk/at-spi2-core.bst
-- gnome-sdk.bst:sdk/brotli.bst
-- gnome-sdk.bst:sdk/enchant-2.bst
-- gnome-sdk.bst:sdk/geoclue.bst
-- gnome-sdk.bst:sdk/gobject-introspection.bst
-- gnome-sdk.bst:sdk/gst-plugins-base.bst
-- gnome-sdk.bst:sdk/libnotify.bst
-- gnome-sdk.bst:sdk/libsecret.bst
-- gnome-sdk.bst:sdk/libsoup.bst
-- gnome-sdk.bst:sdk/libwpe.bst
-- gnome-sdk.bst:sdk/openjpeg.bst
-- gnome-sdk.bst:sdk/pango.bst
-- gnome-sdk.bst:sdk/woff2.bst
-- gnome-sdk.bst:sdk/wpebackend-fdo.bst
-
-runtime-depends:
-- gnome-sdk-sdk/gst-plugins-good.bst
-- gnome-sdk.bst:sdk/gst-libav.bst
-- gnome-sdk.bst:sdk/gst-plugins-bad.bst
-
-# dummy dependency so this is staged on top of the element from gnome-sdk
-- gnome-sdk.bst:sdk/WebKitGTK.bst
-
-variables:
-  webkitgtk_toolchain: ''
-  endless_arch_options: ''
-  (?):
-  - arch == "i686" or arch == "arm":
-      webkitgtk_toolchain: -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=toolchain.%{arch}
-  - arch == "arm":
-      endless_arch_options: |
-        -DENABLE_GLES2=ON
-  cmake-local: >-
-    -DPORT=GTK
-    -DENABLE_BUBBLEWRAP_SANDBOX=OFF
-    %{webkitgtk_toolchain}
-    %{endless_arch_options}
 (?):
-- arch == "i686":
-    environment:
-      CFLAGS: '%{flags_i686} -g1'
-      CXXFLAGS: '%{flags_i686} -g1'
 - arch == "arm":
-    environment:
-      CFLAGS: '%{flags_arm} -g1'
-      CXXFLAGS: '%{flags_arm} -g1'
+    depends:
+    - gnome-sdk-sdk/WebKitGTK-endless-arm.bst
+- arch != "arm":
+    depends:
+    - gnome-sdk.bst:sdk/WebKitGTK.bst
 
-public:
-  bst:
-    split-rules:
-      devel:
-        (>):
-        - '%{libdir}/libjavascriptcoregtk-4.0.so'
-        - '%{libdir}/libwebkit2gtk-4.0.so'
-    overlap-whitelist:
-    - '**'
-  cpe:
-    product: webkitgtk+

--- a/elements/sdk-depends/maxwell.bst
+++ b/elements/sdk-depends/maxwell.bst
@@ -5,10 +5,10 @@ build-depends:
 
 depends:
 - gnome-sdk-sdk/gtk+-3.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - gnome-sdk.bst:sdk/glib.bst
 - gnome-sdk.bst:sdk/gobject-introspection.bst
 - gnome-sdk.bst:sdk/json-glib.bst
-- gnome-sdk.bst:sdk/WebKitGTK.bst
 
 sources:
 - kind: git_tag

--- a/elements/sdk-platform.bst
+++ b/elements/sdk-platform.bst
@@ -25,10 +25,11 @@ depends:
 # replaced (patched) elements:
 - gnome-sdk-sdk/gst-plugins-good.bst
 - gnome-sdk-sdk/gtk+-3.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - sdk/os-release.bst
 
 # upstream modules:
-- gnome-sdk.bst:sdk/WebKitGTK.bst
+# - gnome-sdk.bst:sdk/WebKitGTK.bst
 - gnome-sdk.bst:sdk/adwaita-icon-theme.bst
 - gnome-sdk.bst:sdk/appstream-glib.bst
 - gnome-sdk.bst:sdk/at-spi2-atk.bst

--- a/elements/sdk/eos-knowledge-lib.bst
+++ b/elements/sdk/eos-knowledge-lib.bst
@@ -10,7 +10,7 @@ build-depends:
 
 depends:
 - freedesktop-sdk.bst:components/gstreamer.bst
-- gnome-sdk.bst:sdk/WebKitGTK.bst
+- gnome-sdk-sdk/WebKitGTK.bst
 - gnome-sdk.bst:core/evince.bst
 - gnome-sdk.bst:sdk/gjs.bst
 - sdk-depends/emeus.bst


### PR DESCRIPTION
This change adds gnome-sdk-sdk/WebKitGTK.bst to the runtime image, so
that WebKit always uses GLES2 by default on arm. On other architectures,
the element depends on WebKitGTK.bst from gnome-sdk, so no additional
work is required.