### PR TITLE
Update ref for gnome-sdk.bst

### DIFF
--- a/elements/freedesktop-sdk-components/gstreamer-plugins-good.bst
+++ b/elements/freedesktop-sdk-components/gstreamer-plugins-good.bst
@@ -52,11 +52,11 @@ sources:
   url: gitlab_freedesktop_org:gstreamer/gst-plugins-good
   # Changed to track git commit from upstream bst
   # track: '1.16'
-  track: 'd7d290b64c1282398f3265522a33e093b7233310'
+  track: 'ce0723527aa37d5f4d19ef8021c0b2eb8f83b08d'
   submodules:
     common:
       checkout: false
       url: gitlab_freedesktop_org:gstreamer/common
-  ref: 1.16.1-0-gd7d290b64c1282398f3265522a33e093b7233310
+  ref: 1.16.2-0-gce0723527aa37d5f4d19ef8021c0b2eb8f83b08d
 - kind: patch
   path: files/gstreamer-plugins-good/0001-gtkgstwidget-add-ready-to-show-signal.patch

--- a/elements/gnome-sdk-sdk/WebKitGTK-endless-arm.bst
+++ b/elements/gnome-sdk-sdk/WebKitGTK-endless-arm.bst
@@ -13,8 +13,8 @@ kind: cmake
 
 sources:
 - kind: tar
-  url: webkitgtk_org:webkitgtk-2.27.91.tar.xz
-  ref: 30411781f620c33f5542a745930b48a19a6072bea0e68982c1ad863d1148bdea
+  url: webkitgtk_org:webkitgtk-2.28.0.tar.xz
+  ref: 361f3d178f62a9c112cbadfedd46106c34455c26d57a12a28fb3b09178d20e8b
 - kind: patch
   path: gnome-sdk-files/webkitgtk/gtk-doc-introspection-cross-compiling.patch
 - kind: local

--- a/elements/gnome-sdk-sdk/cogl-endless-arm.bst
+++ b/elements/gnome-sdk-sdk/cogl-endless-arm.bst
@@ -11,10 +11,10 @@
 kind: autotools
 
 sources:
-- kind: git_tag
-  url: gitlab_gnome_org:GNOME/cogl.git
-  track: cogl-1.22
-  ref: 1.22.6-22-g122b390bbf4bf4283ef2a94f25a44ed23ead3e05
+sources:
+- kind: tar
+  url: download_gnome_org_sources:cogl/1.22/cogl-1.22.6.tar.xz
+  ref: 6d134bd3e48c067507167c001200b275997fb9c68b08b48ff038211c8c251b75
 
 build-depends:
 - gnome-sdk.bst:sdk/gtk-doc.bst

--- a/elements/gnome-sdk.bst
+++ b/elements/gnome-sdk.bst
@@ -5,7 +5,7 @@ sources:
   url: gitlab_gnome_org:GNOME/gnome-build-meta.git
   track: gnome-3-36
   track-tags: true
-  ref: 3.36.0-0-g01ad861845c42bffa8449d2b1656bfff6696639c
+  ref: 3.36.0-7-g209e9ad8ca2463a478d9375a00fa27b82bc70b45
 
 config:
   options:

--- a/project.conf
+++ b/project.conf
@@ -49,11 +49,12 @@ options:
 # be changed without triggering a rebuild.
 #
 aliases:
-  gitlab_freedesktop_org: https://gitlab.freedesktop.org/
-  git_xapian_org: https://git.xapian.org/
+  download_gnome_org_sources: https://download.gnome.org/sources/
   github_com: https://github.com/
   gitlab_com: https://gitlab.com/
+  gitlab_freedesktop_org: https://gitlab.freedesktop.org/
   gitlab_gnome_org: https://gitlab.gnome.org/
+  git_xapian_org: https://git.xapian.org/
   raw_githubusercontent_com: https://raw.githubusercontent.com/
   webkitgtk_org: https://webkitgtk.org/releases/
 


### PR DESCRIPTION
This version uses a different download URL for fcitx, working around an
issue where gitlab was rejecting our requests.

https://phabricator.endlessm.com/T28284#812251