### PR TITLE
Add libzim-glib and libzim to libdmodel

### DIFF
--- a/elements/sdk-depends/libzim-glib.bst
+++ b/elements/sdk-depends/libzim-glib.bst
@@ -1,0 +1,15 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+depends:
+- gnome-sdk.bst:sdk/glib.bst
+- gnome-sdk.bst:sdk/gobject-introspection.bst
+- sdk-depends/libzim.bst
+
+sources:
+- kind: git_tag
+  url: github_com:birros/libzim-glib
+  track: master
+  ref: v3.2.0-7-g2190b62217ff44a2c047067e2fd52af5dd0f9d16

--- a/elements/sdk-depends/libzim.bst
+++ b/elements/sdk-depends/libzim.bst
@@ -1,0 +1,10 @@
+kind: meson
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+
+sources:
+- kind: git_tag
+  url: github_com:openzim/libzim
+  track: 6.1.1
+  ref: 6.1.1-0-gec13dd11ac4246fba2188896434d0bc25ae38a00

--- a/elements/sdk/libdmodel.bst
+++ b/elements/sdk/libdmodel.bst
@@ -10,6 +10,7 @@ depends:
 - gnome-sdk.bst:sdk/json-glib.bst
 - gnome-sdk.bst:sdk/libsoup.bst
 - sdk-depends/eos-shard.bst
+- sdk-depends/libzim-glib.bst
 - sdk-depends/xapian-glib.bst
 - sdk/eos-sdk.bst
 


### PR DESCRIPTION
This is to build libdmodel after merging https://github.com/endlessm/libdmodel/pull/16.

(I believe I used `bst track` correctly? please double check that).

https://phabricator.endlessm.com/T26276