### PR TITLE
T26276 libzim bst fixes

### DIFF
--- a/elements/sdk-build-depends/googletest.bst
+++ b/elements/sdk-build-depends/googletest.bst
@@ -1,0 +1,10 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+
+sources:
+- kind: git_tag
+  url: github_com:google/googletest.git
+  track: v1.10.x
+  ref: release-1.10.0-0-g703bd9caab50b139428cea1aaff9974ebee5742e

--- a/elements/sdk-depends/libzim-glib.bst
+++ b/elements/sdk-depends/libzim-glib.bst
@@ -2,6 +2,7 @@ kind: meson
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- gnome-sdk.bst:sdk/vala.bst
 
 depends:
 - gnome-sdk.bst:sdk/glib.bst

--- a/elements/sdk-depends/libzim.bst
+++ b/elements/sdk-depends/libzim.bst
@@ -3,6 +3,11 @@ kind: meson
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 
+depends:
+- freedesktop-sdk.bst:bootstrap/zlib.bst
+- freedesktop-sdk.bst:components/icu.bst
+- sdk-depends/xapian-core.bst
+
 sources:
 - kind: git_tag
   url: github_com:openzim/libzim

--- a/elements/sdk-depends/libzim.bst
+++ b/elements/sdk-depends/libzim.bst
@@ -2,6 +2,7 @@ kind: meson
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
+- sdk-build-depends/googletest.bst
 
 depends:
 - freedesktop-sdk.bst:bootstrap/zlib.bst

--- a/elements/sdk-depends/libzim.bst
+++ b/elements/sdk-depends/libzim.bst
@@ -13,3 +13,5 @@ sources:
   url: github_com:openzim/libzim
   track: 6.1.1
   ref: 6.1.1-0-gec13dd11ac4246fba2188896434d0bc25ae38a00
+- kind: patch
+  path: files/libzim/0001-Fallback-to-xapian-core-1.5-dependency-if-xapian-cor.patch

--- a/files/libzim/0001-Fallback-to-xapian-core-1.5-dependency-if-xapian-cor.patch
+++ b/files/libzim/0001-Fallback-to-xapian-core-1.5-dependency-if-xapian-cor.patch
@@ -1,0 +1,45 @@
+From ffe5c00f02cdb4d5f662699745cf6b9125b569c1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Dami=C3=A1n=20Nohales?= <damiannohales@gmail.com>
+Date: Thu, 30 Apr 2020 12:50:09 -0300
+Subject: [PATCH] Fallback to xapian-core-1.5 dependency if xapian-core is not
+ found
+
+---
+ meson.build | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 362c828..936c118 100644
+--- a/meson.build
++++ b/meson.build
+@@ -33,9 +33,17 @@ lzma_dep = dependency('liblzma', static:static_linkage)
+ zstd_dep = dependency('libzstd', required:false, static:static_linkage)
+ conf.set('ENABLE_ZSTD', zstd_dep.found())
+ 
+-xapian_dep = dependency('xapian-core',
++xapian_pc_dep = 'xapian-core'
++xapian_dep = dependency(xapian_pc_dep,
+                         required:false,
+                         static:static_linkage)
++if not xapian_dep.found()
++  # Xapian 1.5 has a versioned xapian-core pkg-config file
++  xapian_pc_dep = 'xapian-core-1.5'
++  xapian_dep = dependency(xapian_pc_dep,
++                          required:false,
++                          static:static_linkage)
++endif
+ conf.set('ENABLE_XAPIAN', xapian_dep.found())
+ 
+ pkg_requires = ['liblzma']
+@@ -56,7 +64,7 @@ if zstd_dep.found()
+     pkg_requires += ['libzstd']
+ endif
+ if xapian_dep.found()
+-    pkg_requires += ['xapian-core']
++    pkg_requires += [xapian_pc_dep]
+     icu_dep = dependency('icu-i18n', static:static_linkage)
+     pkg_requires += ['icu-i18n']
+ else
+-- 
+2.25.1
+


### PR DESCRIPTION
Fixes for https://github.com/endlessm/endless-sdk-flatpak/pull/77

* Fixed missing `vapigen` error in `libzim-glib`
* Added `googletest` so `libzim`'s Meson doesn't have to build it itself
* Patched `libzim` so it can fallback to `xapian-core-1.5`

https://phabricator.endlessm.com/T26276