### PR TITLE
Remove bundle data from appstream metainfo

### DIFF
--- a/com.endlessm.apps.Platform.appdata.xml.in
+++ b/com.endlessm.apps.Platform.appdata.xml.in
@@ -9,6 +9,5 @@
   <description><p>The Endless Application Platform runtime is shared by Endless content applications. The runtime is layered on top of the Freedesktop runtime and adds shared libraries used by Endless apps.</p></description>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
-  <bundle type="flatpak" runtime="com.endlessm.apps.Platform/@@SDK_ARCH@@/@@SDK_BRANCH@@" sdk="com.endlessm.apps.Sdk/@@SDK_ARCH@@/@@SDK_BRANCH@@">runtime/com.endlessm.apps.Platform/@@SDK_ARCH@@/@@SDK_BRANCH@@</bundle>
 </component>
 

--- a/com.endlessm.apps.Sdk.appdata.xml.in
+++ b/com.endlessm.apps.Sdk.appdata.xml.in
@@ -9,6 +9,5 @@
   <description><p>The Endless Application Platform runtime is shared by Endless content applications. This SDK is used to build applications that use this runtime. The runtime is layered on top of the Freedesktop runtime and adds shared libraries used by Endless apps.</p></description>
   <url type="homepage">https://endlessos.com/</url>
   <project_group>Endless</project_group>
-  <bundle type="flatpak" runtime="com.endlessm.apps.Platform/@@SDK_ARCH@@/@@SDK_BRANCH@@" sdk="com.endlessm.apps.Sdk/@@SDK_ARCH@@/@@SDK_BRANCH@@">runtime/com.endlessm.apps.Sdk/@@SDK_ARCH@@/@@SDK_BRANCH@@</bundle>
 </component>
 


### PR DESCRIPTION
On older flatpak as used in our infrastructure this causes a segfault
when `flatpak build-update-repo` tries to construct the global appstream
XML. As it turns out, flatpak tries to throw out any `<bundle>` nodes it
finds and always constructs a new one based on the flatpak metadata. So,
even though this information is correct, it's ignored.

https://phabricator.endlessm.com/T30093