### PR TITLE
T30304 sdk element tests

### DIFF
--- a/elements/sdk-build-depends/hotdoc-modular-framework.bst
+++ b/elements/sdk-build-depends/hotdoc-modular-framework.bst
@@ -5,6 +5,7 @@ build-depends:
 
 depends:
 - sdk-build-depends/hotdoc.bst
+- sdk-depends/python3-pyyaml.bst
 
 sources:
 - kind: git_tag

--- a/elements/sdk-depends/eos-knowledge-content-renderer.bst
+++ b/elements/sdk-depends/eos-knowledge-content-renderer.bst
@@ -11,12 +11,6 @@ depends:
 - sdk-depends/sassc.bst
 - sdk/eos-sdk.bst
 
-variables:
-  (?):
-  - eos_tests:
-      meson-local: |
-        -Djasmine_junit_reports_dir="%{build-root}/_reports"
-
 sources:
 - kind: git_tag
   url: github_com:endlessm/eos-knowledge-content-renderer.git

--- a/elements/sdk-depends/eos-shard.bst
+++ b/elements/sdk-depends/eos-shard.bst
@@ -2,7 +2,6 @@ kind: autotools
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
-- sdk-build-depends/jasmine-gjs.bst
 
 depends:
 - gnome-sdk.bst:sdk/glib.bst

--- a/elements/sdk-depends/eos-shard.bst
+++ b/elements/sdk-depends/eos-shard.bst
@@ -2,6 +2,7 @@ kind: autotools
 
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+- sdk-build-depends/jasmine-gjs.bst
 
 depends:
 - gnome-sdk.bst:sdk/glib.bst

--- a/elements/sdk/eos-knowledge-lib.bst
+++ b/elements/sdk/eos-knowledge-lib.bst
@@ -32,10 +32,6 @@ variables:
 
 environment:
   HOTDOC: "%{bindir}/python3 %{bindir}/hotdoc"
-  (?):
-  - eos_tests:
-      JASMINE_JUNIT_REPORTS_DIR: "%{build-root}/_reports"
-      EOS_COVERAGE_DIR: "%{build-root}/_coverage"
 
 sources:
 - kind: git_tag

--- a/elements/sdk/eos-knowledge-lib.bst
+++ b/elements/sdk/eos-knowledge-lib.bst
@@ -5,7 +5,6 @@ build-depends:
 - sdk-build-depends/eos-hotdoc-theme.bst
 - sdk-build-depends/hotdoc-modular-framework.bst
 - sdk-build-depends/hotdoc.bst
-- sdk-build-depends/jasmine-gjs.bst
 - sdk-build-depends/lcov.bst
 
 depends:

--- a/elements/sdk/eos-metrics.bst
+++ b/elements/sdk/eos-metrics.bst
@@ -8,6 +8,7 @@ build-depends:
 depends:
 - gnome-sdk.bst:sdk/glib.bst
 - gnome-sdk.bst:sdk/gobject-introspection.bst
+- gnome-sdk.bst:sdk/pygobject.bst
 - freedesktop-sdk.bst:components/python3-dbus.bst
 
 variables:

--- a/elements/sdk/eos-sdk.bst
+++ b/elements/sdk/eos-sdk.bst
@@ -20,12 +20,6 @@ variables:
     --disable-js-doc \
     --disable-webhelper
 
-environment:
-  (?):
-  - eos_tests:
-      JASMINE_JUNIT_REPORTS_DIR: "%{build-root}/_reports"
-      EOS_COVERAGE_DIR: "%{build-root}/_coverage"
-
 sources:
 - kind: git_tag
   url: github_com:endlessm/eos-sdk.git

--- a/elements/sdk/eos-sdk.bst
+++ b/elements/sdk/eos-sdk.bst
@@ -4,7 +4,6 @@ build-depends:
 - freedesktop-sdk.bst:components/git.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
 - gnome-sdk.bst:sdk/gtk-doc.bst
-- sdk-build-depends/jasmine-gjs.bst
 
 depends:
 - gnome-sdk-sdk/gtk+-3.bst

--- a/elements/sdk/libdmodel.bst
+++ b/elements/sdk/libdmodel.bst
@@ -14,12 +14,6 @@ depends:
 - sdk-depends/xapian-glib.bst
 - sdk/eos-sdk.bst
 
-variables:
-  (?):
-  - eos_tests:
-      meson-local: |
-        -Djasmine_junit_reports_dir="%{build-root}/_reports"
-
 sources:
 - kind: git_tag
   url: github_com:endlessm/libdmodel.git

--- a/elements/tests-build-depends/dbus-test-environment.bst
+++ b/elements/tests-build-depends/dbus-test-environment.bst
@@ -1,0 +1,26 @@
+kind: manual
+
+build-depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+# dummy dependency so this is staged on top of dbus.bst
+runtime-depends:
+- freedesktop-sdk.bst:components/dbus.bst
+
+config:
+  install-commands:
+  - |
+    install -D -t "%{install-root}%{datadir}/dbus-1" session.conf
+  - |
+    install -D -t "%{install-root}%{datadir}/dbus-1" system.conf
+
+public:
+  bst:
+    overlap-whitelist:
+    - '**'
+
+sources:
+- kind: local
+  path: files/dbus-test-environment/session.conf
+- kind: local
+  path: files/dbus-test-environment/system.conf

--- a/elements/tests-build-depends/libxmu.bst
+++ b/elements/tests-build-depends/libxmu.bst
@@ -1,0 +1,19 @@
+kind: autotools
+
+build-depends:
+- freedesktop-sdk.bst:components/xorg-util-macros.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+
+depends:
+- freedesktop-sdk.bst:components/xorg-lib-xt.bst
+- tests-build-depends/xorg-server-xvfb.bst
+
+sources:
+- kind: git_tag
+  url: gitlab_freedesktop_org:xorg/lib/libxmu.git
+  track: master
+  match:
+  - libXmu-*
+  exclude:
+  - libXmu-*.99.*
+  ref: libXmu-1.1.3-0-ge9efe2d027b4c46cf6834cc532222f8ad1d1d3c3

--- a/elements/tests-build-depends/xauth.bst
+++ b/elements/tests-build-depends/xauth.bst
@@ -1,0 +1,21 @@
+kind: autotools
+
+build-depends:
+- freedesktop-sdk.bst:components/xorg-proto-xorgproto.bst
+- freedesktop-sdk.bst:components/xorg-util-macros.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+
+depends:
+- tests-build-depends/libxmu.bst
+- tests-build-depends/xorg-server-xvfb.bst
+
+sources:
+- kind: git_tag
+  url: gitlab_freedesktop_org:xorg/app/xauth.git
+  track: master
+  match:
+  - xauth-*
+  exclude:
+  - xauth-*.99.*
+  ref: xauth-1.1-5-gaaf037ec5c576e46318935feaf6e2b7407ff11a0
+

--- a/elements/tests-build-depends/xorg-server-xvfb.bst
+++ b/elements/tests-build-depends/xorg-server-xvfb.bst
@@ -21,6 +21,7 @@ depends:
 - freedesktop-sdk.bst:components/nettle.bst
 - freedesktop-sdk.bst:components/pixman.bst
 - freedesktop-sdk.bst:components/xorg-app-xkbcomp.bst
+- freedesktop-sdk.bst:components/xorg-data-xkeyboard-config.bst
 - freedesktop-sdk.bst:components/xorg-font-util.bst
 - freedesktop-sdk.bst:components/xorg-lib-xdmcp.bst
 - freedesktop-sdk.bst:components/xorg-lib-xfont2.bst

--- a/elements/tests-build-depends/xorg-server-xvfb.bst
+++ b/elements/tests-build-depends/xorg-server-xvfb.bst
@@ -1,0 +1,48 @@
+# Based on components/xorg-server.bst from freedesktop-sdk.
+# <https://gitlab.com/freedesktop-sdk/freedesktop-sdk/blob/19.08/elements/components/xorg-server.bst>
+
+# Changes from upstream:
+# - Enable xvfb for running test suites inside a sandbox.
+# - Remove wayland and systemd dependencies. These are not needed for xvfb.
+
+kind: autotools
+
+build-depends:
+- freedesktop-sdk.bst:components/xorg-proto-xorgproto.bst
+- freedesktop-sdk.bst:components/xorg-util-macros.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-autotools.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+- freedesktop-sdk.bst:components/dummy-gbm.bst
+- freedesktop-sdk.bst:components/libdrm.bst
+- freedesktop-sdk.bst:components/libepoxy.bst
+- freedesktop-sdk.bst:components/libtirpc.bst
+- freedesktop-sdk.bst:components/nettle.bst
+- freedesktop-sdk.bst:components/pixman.bst
+- freedesktop-sdk.bst:components/xorg-app-xkbcomp.bst
+- freedesktop-sdk.bst:components/xorg-font-util.bst
+- freedesktop-sdk.bst:components/xorg-lib-xdmcp.bst
+- freedesktop-sdk.bst:components/xorg-lib-xfont2.bst
+- freedesktop-sdk.bst:components/xorg-lib-xkbfile.bst
+- freedesktop-sdk.bst:components/xorg-lib-xshmfence.bst
+- freedesktop-sdk.bst:components/systemd.bst
+- freedesktop-sdk.bst:components/systemd.bst
+- freedesktop-sdk.bst:components/wayland.bst
+- freedesktop-sdk.bst:components/wayland-protocols.bst
+
+variables:
+  conf-local: |
+    --enable-xvfb
+
+sources:
+- kind: git_tag
+  url: gitlab_freedesktop_org:xorg/xserver.git
+  track: master
+  track-extra:
+  - server-1.20-branch
+  match:
+  - xorg-server-*
+  exclude:
+  - xorg-server-*.99.*
+  ref: xorg-server-1.20.7-0-g489f4191f3c881c6c8acce97ec612167a4ae0f33

--- a/elements/tests-build-depends/xvfb-run.bst
+++ b/elements/tests-build-depends/xvfb-run.bst
@@ -1,0 +1,19 @@
+kind: manual
+
+build-depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+depends:
+- tests-build-depends/xauth.bst
+- tests-build-depends/xorg-server-xvfb.bst
+
+config:
+  install-commands:
+  - |
+    install -Dm755 -t "%{install-root}%{bindir}" debian/local/xvfb-run
+
+sources:
+- kind: git_tag
+  url: salsa_debian_org:xorg-team/xserver/xorg-server.git
+  track: debian-unstable
+  ref: xorg-server-2_1.20.8-2-0-g6ff26b8d4a9492ad4b1edf2577b16911a860440c

--- a/elements/tests.bst
+++ b/elements/tests.bst
@@ -1,0 +1,14 @@
+kind: stack
+
+depends:
+- tests/sdk/basin.bst
+- tests/sdk-build-depends/hotdoc-modular-framework.bst
+- tests/sdk-depends/emeus.bst
+- tests/sdk-depends/eos-knowledge-content-renderer.bst
+- tests/sdk-depends/eos-shard.bst
+- tests/sdk-depends/maxwell.bst
+- tests/sdk-depends/xapian-glib.bst
+# - tests/sdk/eos-knowledge-lib.bst
+# - tests/sdk/eos-metrics.bst
+- tests/sdk/eos-sdk.bst
+- tests/sdk/libdmodel.bst

--- a/elements/tests.bst
+++ b/elements/tests.bst
@@ -8,7 +8,7 @@ depends:
 - tests/sdk-depends/eos-shard.bst
 - tests/sdk-depends/maxwell.bst
 - tests/sdk-depends/xapian-glib.bst
-# - tests/sdk/eos-knowledge-lib.bst
-# - tests/sdk/eos-metrics.bst
+- tests/sdk/eos-knowledge-lib.bst
+- tests/sdk/eos-metrics.bst
 - tests/sdk/eos-sdk.bst
 - tests/sdk/libdmodel.bst

--- a/elements/tests/sdk-build-depends/hotdoc-modular-framework.bst
+++ b/elements/tests/sdk-build-depends/hotdoc-modular-framework.bst
@@ -1,0 +1,9 @@
+kind: pip
+
+(@): elements/sdk-build-depends/hotdoc-modular-framework.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      python3 setup.py test

--- a/elements/tests/sdk-depends/emeus.bst
+++ b/elements/tests/sdk-depends/emeus.bst
@@ -1,0 +1,9 @@
+kind: meson
+
+(@): elements/sdk-depends/emeus.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{ninja} test

--- a/elements/tests/sdk-depends/eos-knowledge-content-renderer.bst
+++ b/elements/tests/sdk-depends/eos-knowledge-content-renderer.bst
@@ -2,6 +2,10 @@ kind: meson
 
 (@): elements/sdk-depends/eos-knowledge-content-renderer.bst
 
+build-depends:
+  (>):
+  - sdk-build-depends/jasmine-gjs.bst
+
 variables:
   meson-local: |
     -Djasmine_junit_reports_dir="%{build-root}/_reports"

--- a/elements/tests/sdk-depends/eos-knowledge-content-renderer.bst
+++ b/elements/tests/sdk-depends/eos-knowledge-content-renderer.bst
@@ -1,0 +1,13 @@
+kind: meson
+
+(@): elements/sdk-depends/eos-knowledge-content-renderer.bst
+
+variables:
+  meson-local: |
+    -Djasmine_junit_reports_dir="%{build-root}/_reports"
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{ninja} test

--- a/elements/tests/sdk-depends/eos-shard.bst
+++ b/elements/tests/sdk-depends/eos-shard.bst
@@ -6,4 +6,4 @@ config:
   install-commands:
     (>):
     - |
-      %{make} distcheck
+      %{make} check

--- a/elements/tests/sdk-depends/eos-shard.bst
+++ b/elements/tests/sdk-depends/eos-shard.bst
@@ -1,0 +1,9 @@
+kind: autotools
+
+(@): elements/sdk-depends/eos-shard.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{make} distcheck

--- a/elements/tests/sdk-depends/eos-shard.bst
+++ b/elements/tests/sdk-depends/eos-shard.bst
@@ -2,6 +2,10 @@ kind: autotools
 
 (@): elements/sdk-depends/eos-shard.bst
 
+build-depends:
+  (>):
+  - sdk-build-depends/jasmine-gjs.bst
+
 config:
   install-commands:
     (>):

--- a/elements/tests/sdk-depends/maxwell.bst
+++ b/elements/tests/sdk-depends/maxwell.bst
@@ -1,0 +1,9 @@
+kind: meson
+
+(@): elements/sdk-depends/maxwell.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{ninja} test

--- a/elements/tests/sdk-depends/xapian-glib.bst
+++ b/elements/tests/sdk-depends/xapian-glib.bst
@@ -1,0 +1,9 @@
+kind: meson
+
+(@): elements/sdk-depends/xapian-glib.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{ninja} test

--- a/elements/tests/sdk/basin.bst
+++ b/elements/tests/sdk/basin.bst
@@ -1,0 +1,9 @@
+kind: autotools
+
+(@): elements/sdk/basin.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{make} check

--- a/elements/tests/sdk/eos-knowledge-lib.bst
+++ b/elements/tests/sdk/eos-knowledge-lib.bst
@@ -1,0 +1,18 @@
+kind: autotools
+
+(@): elements/sdk/eos-knowledge-lib.bst
+
+build-depends:
+  (>):
+  - tests-build-depends/xvfb-run.bst
+
+environment:
+  JASMINE_JUNIT_REPORTS_DIR: "%{build-root}/_reports"
+  EOS_COVERAGE_DIR: "%{build-root}/_coverage"
+
+config:
+  install-commands:
+    (>):
+    - |
+      xvfb-run -s '-screen 0 800x600x24' --auto-servernum -e /dev/stderr \
+      %{make} check

--- a/elements/tests/sdk/eos-knowledge-lib.bst
+++ b/elements/tests/sdk/eos-knowledge-lib.bst
@@ -4,6 +4,7 @@ kind: autotools
 
 build-depends:
   (>):
+  - sdk-build-depends/jasmine-gjs.bst
   - tests-build-depends/xvfb-run.bst
 
 environment:

--- a/elements/tests/sdk/eos-metrics.bst
+++ b/elements/tests/sdk/eos-metrics.bst
@@ -2,6 +2,10 @@ kind: autotools
 
 (@): elements/sdk/eos-metrics.bst
 
+build-depends:
+  (>):
+  - tests-build-depends/dbus-test-environment.bst
+
 config:
   install-commands:
     (>):

--- a/elements/tests/sdk/eos-metrics.bst
+++ b/elements/tests/sdk/eos-metrics.bst
@@ -1,0 +1,9 @@
+kind: autotools
+
+(@): elements/sdk/eos-metrics.bst
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{make} check

--- a/elements/tests/sdk/eos-sdk.bst
+++ b/elements/tests/sdk/eos-sdk.bst
@@ -1,0 +1,18 @@
+kind: autotools
+
+(@): elements/sdk/eos-sdk.bst
+
+build-depends:
+  (>):
+  - tests-build-depends/xvfb-run.bst
+
+environment:
+  JASMINE_JUNIT_REPORTS_DIR: "%{build-root}/_reports"
+  EOS_COVERAGE_DIR: "%{build-root}/_coverage"
+
+config:
+  install-commands:
+    (>):
+    - |
+      xvfb-run -s '-screen 0 800x600x24' --auto-servernum -e /dev/stderr \
+      %{make} check

--- a/elements/tests/sdk/eos-sdk.bst
+++ b/elements/tests/sdk/eos-sdk.bst
@@ -4,6 +4,7 @@ kind: autotools
 
 build-depends:
   (>):
+  - sdk-build-depends/jasmine-gjs.bst
   - tests-build-depends/xvfb-run.bst
 
 environment:

--- a/elements/tests/sdk/libdmodel.bst
+++ b/elements/tests/sdk/libdmodel.bst
@@ -1,0 +1,13 @@
+kind: meson
+
+(@): elements/sdk/libdmodel.bst
+
+variables:
+  meson-local: |
+    -Djasmine_junit_reports_dir="%{build-root}/_reports"
+
+config:
+  install-commands:
+    (>):
+    - |
+      %{ninja} test

--- a/elements/tests/sdk/libdmodel.bst
+++ b/elements/tests/sdk/libdmodel.bst
@@ -2,6 +2,10 @@ kind: meson
 
 (@): elements/sdk/libdmodel.bst
 
+build-depends:
+  (>):
+  - sdk-build-depends/jasmine-gjs.bst
+
 variables:
   meson-local: |
     -Djasmine_junit_reports_dir="%{build-root}/_reports"

--- a/files/dbus-test-environment/session.conf
+++ b/files/dbus-test-environment/session.conf
@@ -1,0 +1,17 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>session</type>
+  <keep_umask/>
+  <listen>unix:tmpdir=/tmp</listen>
+  <auth>ANONYMOUS</auth>
+  <allow_anonymous/>
+  <standard_system_servicedirs />
+
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+

--- a/files/dbus-test-environment/system.conf
+++ b/files/dbus-test-environment/system.conf
@@ -1,0 +1,17 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <type>system</type>
+  <keep_umask/>
+  <listen>unix:tmpdir=/tmp</listen>
+  <auth>ANONYMOUS</auth>
+  <allow_anonymous/>
+  <standard_system_servicedirs />
+
+  <policy context="default">
+    <allow send_destination="*" eavesdrop="true"/>
+    <allow eavesdrop="true"/>
+    <allow own="*"/>
+  </policy>
+</busconfig>
+

--- a/project.conf
+++ b/project.conf
@@ -50,12 +50,13 @@ options:
 #
 aliases:
   download_gnome_org_sources: https://download.gnome.org/sources/
+  git_xapian_org: https://git.xapian.org/
   github_com: https://github.com/
   gitlab_com: https://gitlab.com/
   gitlab_freedesktop_org: https://gitlab.freedesktop.org/
   gitlab_gnome_org: https://gitlab.gnome.org/
-  git_xapian_org: https://git.xapian.org/
   raw_githubusercontent_com: https://raw.githubusercontent.com/
+  salsa_debian_org: https://salsa.debian.org/
   webkitgtk_org: https://webkitgtk.org/releases/
 
 # Some overrides to the default sandbox execution environment

--- a/project.conf
+++ b/project.conf
@@ -35,11 +35,6 @@ options:
     - i686
     - x86_64
 
-  eos_tests:
-    type: bool
-    description: Whether to build test suites
-    default: False
-
 # Source aliases.
 #
 # These are used in the individual element.bst files in


### PR DESCRIPTION
This moves most of the logic for running tests for SDK components from [eos-build](https://github.com/endlessm/eos-build/blob/master/ci-integration/jenkins-jobs/sdk.yaml#L104) to here.

Some benefits to this approach:

- We can remove a bunch of project-specific code from Jenkins. All it needs to know is what the test element is called for a particular SDK component's repository, and the rest is managed here.
- By running tests via buildstream, we are able to have a standardized test environment that is the same on Jenkins as on someone's development system.
- Test runs are in the best case very fast: buildstream will reuse build artifacts where possible.

Some disadvantages:

- Test elements here are usually _duplicates_ of the originals (using buildstream's file include syntax), rather than _dependants_. This means BuildStream will always need to rebuild a test element separately from the canonical element if it has changed, and to run tests against a local git checkout you need to open a workspace for the test element rather than the canonical one. On the other hand, this means we no longer need the eos_tests variable which was used to generate a special build of certain components with the appropriate test configuration.