### PR TITLE
project: Use Endless BuildStream artifact cache

### DIFF
--- a/project.conf
+++ b/project.conf
@@ -35,6 +35,13 @@ options:
     - i686
     - x86_64
 
+# Artifact servers.
+#
+# These are used to fetch built artifacts when available.
+#
+artifacts:
+- url: https://bstcache.endlessos.org
+
 # Source aliases.
 #
 # These are used in the individual element.bst files in


### PR DESCRIPTION
This will allow pulling from our BuildStream artifact server. An
additional URL for pushes will be enabled in Jenkins when the necessary
TLS client certificate is available.

Don't merge this until endlessm/eos-administration#912 is merged and deployed since the production artifact server is not up yet.

https://phabricator.endlessm.com/T29643