### PR TITLE
Disable coverage for eos-knowledge-lib

### DIFF
--- a/elements/sdk/eos-knowledge-lib.bst
+++ b/elements/sdk/eos-knowledge-lib.bst
@@ -26,7 +26,6 @@ variables:
   conf-local: |
     --disable-js-doc \
     --enable-documentation \
-    --enable-coverage \
     --with-mathjax-dir="%{datadir}/javascript/mathjax"
 
 environment:

--- a/elements/tests/sdk/eos-knowledge-lib.bst
+++ b/elements/tests/sdk/eos-knowledge-lib.bst
@@ -9,7 +9,6 @@ build-depends:
 
 environment:
   JASMINE_JUNIT_REPORTS_DIR: "%{build-root}/_reports"
-  EOS_COVERAGE_DIR: "%{build-root}/_coverage"
 
 config:
   install-commands:


### PR DESCRIPTION
This is not working in bst, let's disable it for now.

https://phabricator.endlessm.com/T30490