### PR TITLE
Upgrade libzim to 6.1.8

### DIFF
--- a/elements/sdk-depends/libzim.bst
+++ b/elements/sdk-depends/libzim.bst
@@ -12,6 +12,6 @@ depends:
 sources:
 - kind: git_tag
   url: github_com:openzim/libzim
-  track: 6.1.1
+  track: 6.1.8
 - kind: patch
   path: files/libzim/0001-Fallback-to-xapian-core-1.5-dependency-if-xapian-cor.patch

--- a/project.refs
+++ b/project.refs
@@ -75,7 +75,7 @@ projects:
     - {}
     - {}
     sdk-depends/libzim.bst:
-    - ref: 6.1.1-0-gec13dd11ac4246fba2188896434d0bc25ae38a00
+    - ref: 6.1.8-0-g5996f7962758da8afc4c28d31abb7624b79e822e
     - {}
     sdk/libdmodel.bst:
     - ref: 75622da10c33b04ffa3c3ace8a118f592cc985c5


### PR DESCRIPTION
I tested the English Encyclopedia with libzim 6.1.8 and the loading performance was greatly improved, I think its worth to make a patch release for this.

https://phabricator.endlessm.com/T30560