### PR TITLE
Don't set NET_WM_PID when sandboxed

### DIFF
--- a/com.endlessm.apps.Sdk.json.tmpl
+++ b/com.endlessm.apps.Sdk.json.tmpl
@@ -236,7 +236,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/ptomato/jasmine-gjs"
+                    "url": "https://github.com/ptomato/jasmine-gjs",
+                    "commit": "88c2e56c7e50ab6f51008091e995771bf957fd89"
                 }
             ]
         },

--- a/generate-manifest.py
+++ b/generate-manifest.py
@@ -77,7 +77,8 @@ def edit_manifest(data, arch, branch, runtime_version):
     gtk_patches = {
         'all': [
             'gtk3-fix-atk-gjs-crash.patch',
-            'gtk3-CSS-eos-cairo-filter-property.patch'
+            'gtk3-CSS-eos-cairo-filter-property.patch',
+            'gtk3-x11-Don-t-set-NET_WM_PID-when-sandboxed.patch'
         ],
         'arm': [
             'gtk3-egl-x11.patch',

--- a/gtk3-x11-Don-t-set-NET_WM_PID-when-sandboxed.patch
+++ b/gtk3-x11-Don-t-set-NET_WM_PID-when-sandboxed.patch
@@ -1,0 +1,132 @@
+From 0bb66f2cbb178b830e9a850e25347abdab113967 Mon Sep 17 00:00:00 2001
+From: Matthias Clasen <mclasen@redhat.com>
+Date: Mon, 28 May 2018 12:04:17 -0400
+Subject: [PATCH] gdk: Add a private api to find sandboxes
+
+This will be used in more places in the future.
+
+Use a simpler sandbox check
+
+No need to use the runtime dir and allocate a string.
+We can just check in /.
+
+x11: Don't set NET_WM_PID when sandboxed
+
+It is not useful, and some window managers misinterpret it and
+add some "runs as root" indication to the window decoration.
+
+See https://github.com/mate-desktop/marco/issues/301
+---
+ gdk/gdk-private.h        |  2 ++
+ gdk/gdk.c                |  7 ++++++-
+ gdk/x11/gdkdisplay-x11.c | 15 +++++++++------
+ gdk/x11/gdkwindow-x11.c  | 17 ++++++++++-------
+ 4 files changed, 27 insertions(+), 14 deletions(-)
+
+diff --git a/gdk/gdk-private.h b/gdk/gdk-private.h
+index 69d126638f..e292429fd4 100644
+--- a/gdk/gdk-private.h
++++ b/gdk/gdk-private.h
+@@ -77,4 +77,6 @@ typedef struct {
+ GDK_AVAILABLE_IN_ALL
+ GdkPrivateVTable *      gdk__private__  (void);
+ 
++gboolean gdk_running_in_sandbox (void);
++
+ #endif /* __GDK__PRIVATE_H__ */
+diff --git a/gdk/gdk.c b/gdk/gdk.c
+index 22d7841815..f4e4413300 100644
+--- a/gdk/gdk.c
++++ b/gdk/gdk.c
+@@ -468,6 +468,12 @@ gdk_display_open_default (void)
+   return display;
+ }
+ 
++gboolean
++gdk_running_in_sandbox (void)
++{
++  return g_file_test ("/.flatpak-info", G_FILE_TEST_EXISTS);
++}
++
+ /**
+  * gdk_display_open_default_libgtk_only:
+  *
+@@ -601,7 +607,6 @@ gdk_init (int *argc, char ***argv)
+  * management for you.
+  */
+ 
+-
+ /**
+  * gdk_threads_enter:
+  *
+diff --git a/gdk/x11/gdkdisplay-x11.c b/gdk/x11/gdkdisplay-x11.c
+index 46421cbf41..659b9fa380 100644
+--- a/gdk/x11/gdkdisplay-x11.c
++++ b/gdk/x11/gdkdisplay-x11.c
+@@ -1555,7 +1555,6 @@ _gdk_x11_display_open (const gchar *display_name)
+   gchar *argv[1];
+ 
+   XClassHint *class_hint;
+-  gulong pid;
+   gint ignore;
+   gint maj, min;
+ 
+@@ -1726,11 +1725,15 @@ _gdk_x11_display_open (const gchar *display_name)
+   if (gdk_sm_client_id)
+     set_sm_client_id (display, gdk_sm_client_id);
+ 
+-  pid = getpid ();
+-  XChangeProperty (display_x11->xdisplay,
+-		   display_x11->leader_window,
+-		   gdk_x11_get_xatom_by_name_for_display (display, "_NET_WM_PID"),
+-		   XA_CARDINAL, 32, PropModeReplace, (guchar *) & pid, 1);
++  if (!gdk_running_in_sandbox ())
++    {
++      /* if sandboxed, we're likely in a pid namespace and would only confuse the wm with this */
++      pid_t pid = getpid ();
++      XChangeProperty (display_x11->xdisplay,
++                       display_x11->leader_window,
++                       gdk_x11_get_xatom_by_name_for_display (display, "_NET_WM_PID"),
++                       XA_CARDINAL, 32, PropModeReplace, (guchar *) & pid, 1);
++    }
+ 
+   /* We don't yet know a valid time. */
+   display_x11->user_time = 0;
+diff --git a/gdk/x11/gdkwindow-x11.c b/gdk/x11/gdkwindow-x11.c
+index e484b58253..00a3a6d268 100644
+--- a/gdk/x11/gdkwindow-x11.c
++++ b/gdk/x11/gdkwindow-x11.c
+@@ -902,7 +902,6 @@ setup_toplevel_window (GdkWindow *window,
+   XID xid = GDK_WINDOW_XID (window);
+   GdkX11Screen *x11_screen = GDK_X11_SCREEN (GDK_WINDOW_SCREEN (parent));
+   XSizeHints size_hints;
+-  long pid;
+   Window leader_window;
+ 
+   set_wm_protocols (window);
+@@ -933,12 +932,16 @@ setup_toplevel_window (GdkWindow *window,
+   /* This will set WM_CLIENT_MACHINE and WM_LOCALE_NAME */
+   XSetWMProperties (xdisplay, xid, NULL, NULL, NULL, 0, NULL, NULL, NULL);
+   
+-  pid = getpid ();
+-  XChangeProperty (xdisplay, xid,
+-		   gdk_x11_get_xatom_by_name_for_display (x11_screen->display, "_NET_WM_PID"),
+-		   XA_CARDINAL, 32,
+-		   PropModeReplace,
+-		   (guchar *)&pid, 1);
++  if (!gdk_running_in_sandbox ())
++    {
++      /* if sandboxed, we're likely in a pid namespace and would only confuse the wm with this */
++      pid_t pid = getpid ();
++      XChangeProperty (xdisplay, xid,
++                       gdk_x11_get_xatom_by_name_for_display (x11_screen->display, "_NET_WM_PID"),
++                       XA_CARDINAL, 32,
++                       PropModeReplace,
++                       (guchar *)&pid, 1);
++    }
+ 
+   leader_window = GDK_X11_DISPLAY (x11_screen->display)->leader_window;
+   if (!leader_window)
+-- 
+2.28.0
+


### PR DESCRIPTION
This backports a change applied in newer versions of GTK, fixing an issue where knowledge apps were not visible when using Zoom screen sharing.

https://phabricator.endlessm.com/T27285