### PR TITLE
project: Use upstream's artifact servers

### DIFF
--- a/project.conf
+++ b/project.conf
@@ -43,7 +43,12 @@ options:
 # These are used to fetch built artifacts when available.
 #
 artifacts:
-- url: https://bstcache.endlessos.org
+# GNOME SDK's artifact server from
+# https://gitlab.gnome.org/GNOME/gnome-build-meta/-/blob/master/project.conf
+- url: https://m3-large-x86.gnome.org:11003
+# Freedesktop SDK's artifact server from
+# https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/master/project.conf
+- url: https://cache.freedesktop-sdk.io:11001
 
 # Source aliases.
 #


### PR DESCRIPTION
We're not developing or building this project anymore, so we'd like to get rid of the artifact server that this is the only user of. Instead, just use upstream's artifact servers for GNOME SDK and Freedesktop SDK. It will be probably be pointless since the software versions specified here are likely long gone from those servers, but it's better than a pile of errors trying to use a non-existent server.

https://phabricator.endlessm.com/T35728

The alternative is just to remove the artifacts configuration and then you'd for sure have to build everything locally.